### PR TITLE
Fix Typo

### DIFF
--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -65,10 +65,10 @@ It is also important to note that while this document provides the criteria agai
 * Standard GET /admin/health endpoint returning a 200 response (5) 
  * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
 * High Availability (HA) compliant (5, 14, 15)
- * Possible red flags:
-  * Connection affinity / sticky sessions / etc. are used
-  * Local container storage is used
-  * Services are stateful
+  * Possible red flags:
+    * Connection affinity / sticky sessions / etc. are used
+    * Local container storage is used
+    * Services are stateful
 * Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
   * _e.g. PostgreSQL, ElasticSearch, etc._ (3, 5, 12)
 

--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -64,7 +64,7 @@ It is also important to note that while this document provides the criteria agai
 * The module responds with a tenant’s content based on x-okapi-tenant header (7)
 * Standard GET /admin/health endpoint returning a 200 response (5) 
  * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
-* High Availity (HA) compliant (5, 14, 15)
+* High Availability (HA) compliant (5, 14, 15)
  * Possible red flags:
   * Connection affinity / sticky sessions / etc. are used
   * Local container storage is used


### PR DESCRIPTION
I noticed a typo in the Acceptance Criteria...  "High Availity" -> "High Availability"