### PR TITLE
TCR 24

### DIFF
--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -26,6 +26,7 @@ TCR-24 Mod Settings
 * [X] All API endpoints are documented in RAML or OpenAPI
 * [X] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
   * The permissions, as expressed in the reference commit given to the evaluators, do adhere to the guidelines expressed [here](https://dev.folio.org/guidelines/naming-conventions/). However, it should be noted, that in the master branch of this repo, the permissions are all prefixed with "mod-", which is not recommended by our guidelines.
+  * The module developers have stated that the reason for adding the `mod` prefix to each permission is to avoid a collision with existing application setting permissions.
 * [X] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
 * [X] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
   * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_

--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -1,65 +1,52 @@
-# Module acceptance criteria template
-
-## How to use this form
-When performing a technical evaluation of a module, create a copy of this document and use the conventions below to indicate the status of each criterion.  The evaluation results should be placed in the [module_evaluations](https://github.com/folio-org/tech-council/tree/master/module_evaluations) directory and should conform to the following naming convention: `{JIRA Key}_YYYY-MM-DD.MD`, e.g. `TCR-1_2021-11-17.MD`.  The date here is used to differentiate between initial and potential re-evaluation(s).  It should be the date when the evaluation results file was created.
-
-* [x] ACCEPTABLE
-* [x] ~INAPPLICABLE~
-* [ ] UNACCEPTABLE
-  * comments on what was evaluated/not evaluated, why a criterion failed
-
-## [Criteria](https://github.com/folio-org/tech-council/blob/7b10294a5c1c10c7e1a7c5b9f99f04bf07630f06/MODULE_ACCEPTANCE_CRITERIA.MD)
+TCR-24 Mod Settings
 
 ## Shared/Common
-* [ ] Uses Apache 2.0 license
-* [ ] Module build MUST produce a valid module descriptor
-* [ ] Module descriptor MUST include interface requirements for all consumed APIs
-* [ ] Third party dependencies use an Apache 2.0 compatible license
-* [ ] Installation documentation is included
+* [X] Uses Apache 2.0 license
+* [X] Module build MUST produce a valid module descriptor
+* [X] Module descriptor MUST include interface requirements for all consumed APIs
+* [X] Third party dependencies use an Apache 2.0 compatible license
+* [X] Installation documentation is included
   * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
-* [ ] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
-* [ ] Sensitive and environment-specific information is not checked into git repository
-* [ ] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
-* [ ] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
-* [ ] Module gracefully handles the absence of third party systems or related configuration
-* [ ] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
-* [ ] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
-* [ ] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
-
-## Frontend
-* [ ] If provided, End-to-end tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
-  * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
-  * -_note: these tests are defined in https://github.com/folio-org/stripes-testing_
-* [ ] Have i18n support via react-intl and an `en.json` file with English texts
-* [ ] Have WCAG 2.1 AA compliance as measured by a current major version of axe DevTools Chrome Extension
-* [ ] Use the latest release of Stripes at the time of evaluation
-* [ ] Follow relevant existing UI layouts, patterns and norms
-  * -_note: read more about current practices at [https://ux.folio.org/docs/all-guidelines/](https://ux.folio.org/docs/all-guidelines/)_
-  * e.g. Saving state when navigating between apps (or confirming that you'll lose the state)
-* [ ] Must work in the latest version of Chrome (the supported runtime environment) at the time of evaluation
+* [X] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [X] Sensitive and environment-specific information is not checked into git repository
+* [X] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
+  * It would be beneficial the Java version was made explicit in the POM file.  
+* [X] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
+* [X] Module gracefully handles the absence of third party systems or related configuration
+* [X] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [X] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
+* [X] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
 
 ## Backend
-* [ ] Module's repository includes a compliant Module Descriptor
+* [X] Module's repository includes a compliant Module Descriptor
   * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
-* [ ] Environment vars are documented in the ModuleDescriptor
+* [X] Environment vars are documented in the ModuleDescriptor
   * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
-* [ ] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
-* [ ] All API endpoints are documented in RAML or OpenAPI
-* [ ] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
-  * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
-* [ ] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
-* [ ] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+* [X] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
+* [X] All API endpoints are documented in RAML or OpenAPI
+* [X] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+  * The permissions, as expressed in the reference commit given to the evaluators, do adhere to the guidlines expressed [here](https://dev.folio.org/guidelines/naming-conventions/). However, it should be noted, that in the master branch of this repo, the persmissions are all prefixed with "mod-", which is not recomended by our guidlines.
+* [X] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
+* [X] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
   * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
   * -_note: these tests are defined in https://github.com/folio-org/folio-integration-tests_
-* [ ] Data is segregated by tenant at the storage layer
-* [ ] The module doesn't access data in DB schemas other than its own and public
-* [ ] The module responds with a tenant's content based on x-okapi-tenant header
-* [ ] Standard GET `/admin/health` endpoint returning a 200 response
+* [X] Data is segregated by tenant at the storage layer
+* [X] The module doesn't access data in DB schemas other than its own and public
+* [X] The module responds with a tenant's content based on x-okapi-tenant header
+* [X] Standard GET `/admin/health` endpoint returning a 200 response
   * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
-* [ ] High Availability (HA) compliant
+* [X] High Availability (HA) compliant
   * Possible red flags:
     * Connection affinity / sticky sessions / etc. are used
     * Local container storage is used
     * Services are stateful
 * [ ] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
-  * _e.g. PostgreSQL, ElasticSearch, etc._
+  * There are several dependencies of this module that are not on our officially approved technology list. The TC should consider adding them, because support for them is implicit in the acceptance of VertX:
+    * vertx-core
+    * vertx-web
+    * vertx-web-openapi
+    * vertx-rx-java2
+    * vertx-web-api-contract
+    * vertx-pg-client
+    * vertx-lib
+  * Additionally, Solr is used, and should be considered as an addition to the Officially Supported Technologies

--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -41,7 +41,7 @@ TCR-24 Mod Settings
     * Connection affinity / sticky sessions / etc. are used
     * Local container storage is used
     * Services are stateful
-* [ ] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
+* [X] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
   * There are several dependencies of this module that are not on our officially approved technology list. The TC should consider adding them, because support for them is implicit in the acceptance of VertX:
     * vertx-core
     * vertx-web
@@ -50,3 +50,7 @@ TCR-24 Mod Settings
     * vertx-web-api-contract
     * vertx-pg-client
   * Additionally, Solr is referenced but not used and will be removed from the dependencies.
+
+### Additional Notes
+
+It should be noted that there are ongoing conversations about the centralization vs distribution of configuration in the FOLIO project. This review of Mod Settings is not intended to be a comment on that topic in any way. This evaluation was intended to determine if Mod Settings met the technical criterion for acceptance as laid out by the technical council.

--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -1,0 +1,65 @@
+# Module acceptance criteria template
+
+## How to use this form
+When performing a technical evaluation of a module, create a copy of this document and use the conventions below to indicate the status of each criterion.  The evaluation results should be placed in the [module_evaluations](https://github.com/folio-org/tech-council/tree/master/module_evaluations) directory and should conform to the following naming convention: `{JIRA Key}_YYYY-MM-DD.MD`, e.g. `TCR-1_2021-11-17.MD`.  The date here is used to differentiate between initial and potential re-evaluation(s).  It should be the date when the evaluation results file was created.
+
+* [x] ACCEPTABLE
+* [x] ~INAPPLICABLE~
+* [ ] UNACCEPTABLE
+  * comments on what was evaluated/not evaluated, why a criterion failed
+
+## [Criteria](https://github.com/folio-org/tech-council/blob/7b10294a5c1c10c7e1a7c5b9f99f04bf07630f06/MODULE_ACCEPTANCE_CRITERIA.MD)
+
+## Shared/Common
+* [ ] Uses Apache 2.0 license
+* [ ] Module build MUST produce a valid module descriptor
+* [ ] Module descriptor MUST include interface requirements for all consumed APIs
+* [ ] Third party dependencies use an Apache 2.0 compatible license
+* [ ] Installation documentation is included
+  * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
+* [ ] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [ ] Sensitive and environment-specific information is not checked into git repository
+* [ ] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
+* [ ] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
+* [ ] Module gracefully handles the absence of third party systems or related configuration
+* [ ] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [ ] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
+* [ ] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+
+## Frontend
+* [ ] If provided, End-to-end tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+  * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
+  * -_note: these tests are defined in https://github.com/folio-org/stripes-testing_
+* [ ] Have i18n support via react-intl and an `en.json` file with English texts
+* [ ] Have WCAG 2.1 AA compliance as measured by a current major version of axe DevTools Chrome Extension
+* [ ] Use the latest release of Stripes at the time of evaluation
+* [ ] Follow relevant existing UI layouts, patterns and norms
+  * -_note: read more about current practices at [https://ux.folio.org/docs/all-guidelines/](https://ux.folio.org/docs/all-guidelines/)_
+  * e.g. Saving state when navigating between apps (or confirming that you'll lose the state)
+* [ ] Must work in the latest version of Chrome (the supported runtime environment) at the time of evaluation
+
+## Backend
+* [ ] Module's repository includes a compliant Module Descriptor
+  * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
+* [ ] Environment vars are documented in the ModuleDescriptor
+  * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
+* [ ] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
+* [ ] All API endpoints are documented in RAML or OpenAPI
+* [ ] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+  * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
+* [ ] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
+* [ ] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+  * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
+  * -_note: these tests are defined in https://github.com/folio-org/folio-integration-tests_
+* [ ] Data is segregated by tenant at the storage layer
+* [ ] The module doesn't access data in DB schemas other than its own and public
+* [ ] The module responds with a tenant's content based on x-okapi-tenant header
+* [ ] Standard GET `/admin/health` endpoint returning a 200 response
+  * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
+* [ ] High Availability (HA) compliant
+  * Possible red flags:
+    * Connection affinity / sticky sessions / etc. are used
+    * Local container storage is used
+    * Services are stateful
+* [ ] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
+  * _e.g. PostgreSQL, ElasticSearch, etc._

--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -25,7 +25,7 @@ TCR-24 Mod Settings
 * [X] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
 * [X] All API endpoints are documented in RAML or OpenAPI
 * [X] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
-  * The permissions, as expressed in the reference commit given to the evaluators, do adhere to the guidlines expressed [here](https://dev.folio.org/guidelines/naming-conventions/). However, it should be noted, that in the master branch of this repo, the persmissions are all prefixed with "mod-", which is not recomended by our guidlines.
+  * The permissions, as expressed in the reference commit given to the evaluators, do adhere to the guidelines expressed [here](https://dev.folio.org/guidelines/naming-conventions/). However, it should be noted, that in the master branch of this repo, the permissions are all prefixed with "mod-", which is not recommended by our guidelines.
 * [X] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
 * [X] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
   * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
@@ -49,4 +49,4 @@ TCR-24 Mod Settings
     * vertx-web-api-contract
     * vertx-pg-client
     * vertx-lib
-  * Additionally, Solr is used, and should be considered as an addition to the Officially Supported Technologies
+  * Additionally, Solr is referenced but not used and will be removed from the dependencies.

--- a/module_evaluations/TCR-24_2023-01-18.MD
+++ b/module_evaluations/TCR-24_2023-01-18.MD
@@ -48,5 +48,4 @@ TCR-24 Mod Settings
     * vertx-rx-java2
     * vertx-web-api-contract
     * vertx-pg-client
-    * vertx-lib
   * Additionally, Solr is referenced but not used and will be removed from the dependencies.


### PR DESCRIPTION
This review has two areas of note:

1) The permissions, as expressed in the reference commit given to the evaluators, do adhere to the guidelines expressed [here](https://dev.folio.org/guidelines/naming-conventions/). However, it should be noted, that in the master branch of this repo, the permissions are all prefixed with "mod-", which is not recommended by our guidelines. The module developers have stated that the reason for adding the `mod` prefix to each permission is to avoid a collision with existing application setting permissions.

2) There are several dependencies of this module that are not on our officially approved technology list. The TC should consider adding them, because support for them is implicit in the acceptance of VertX:
    * vertx-core
    * vertx-web
    * vertx-web-openapi
    * vertx-rx-java2
    * vertx-web-api-contract
    * vertx-pg-client