### PR TITLE
Clarify conflict of interest line of TCR process

### DIFF
--- a/NEW_MODULE_TECH_EVAL.MD
+++ b/NEW_MODULE_TECH_EVAL.MD
@@ -47,7 +47,8 @@ Information gathered includes:
 
 ## Evaluation
 1. The Technical Council reviews a JIRA board to see if there are any new submissions, and check on the status of evaluations in progress.
-1. If there’s a new submission, the Technical Council finds one or more people to perform the role of Evaluator. The review team will be formed in a way to allow for a fair review and avoid conflicts for interests.
+1. If there’s a new submission, the Technical Council finds one or more people to perform the role of Evaluator. 
+    * The review team will be formed in a way to allow for a fair review and avoid either perceived or actual conflicts of interest.  No members should have participated in the module's development, and at least one member should be independent of the submitter's organization.
     * JIRA workflow: the ticket is transitioned from **SUBMITTED** to **UNDER EVALUATION**
 1. The module is evaluated.
     * If the Evaluator(s) have questions, they may reach out to the Point of Contact for clarification.

--- a/NEW_MODULE_TECH_EVAL.MD
+++ b/NEW_MODULE_TECH_EVAL.MD
@@ -48,7 +48,7 @@ Information gathered includes:
 ## Evaluation
 1. The Technical Council reviews a JIRA board to see if there are any new submissions, and check on the status of evaluations in progress.
 1. If there’s a new submission, the Technical Council finds one or more people to perform the role of Evaluator. 
-    * The review team will be formed in a way to allow for a fair review and avoid either perceived or actual conflicts of interest.  No members should have participated in the module's development, and at least one member should be independent of the submitter's organization.
+    * The review team will be formed in a way to allow for a fair review and avoid either perceived or actual conflicts of interest.  No members should have participated in the module's development, and at least one member should be independent of the submitter's organization.  The lead evaluator will be assigned in JIRA; if the submitting team has concerns about the chosen evaluator they should contact the TC chairs within one week of the assignment.
     * JIRA workflow: the ticket is transitioned from **SUBMITTED** to **UNDER EVALUATION**
 1. The module is evaluated.
     * If the Evaluator(s) have questions, they may reach out to the Point of Contact for clarification.


### PR DESCRIPTION
There was discussion at the [2023-09-06 TC meeting](https://wiki.folio.org/display/TC/2023-09-06+Meeting+notes) about the meaning of the conflict-of-interest line in the TCR process.  Questions about actual vs. perceived conflicts, and whether it matters if the sole reviewer is from the same organization.  This is a proposal to answer those questions.