### PR TITLE
Document new Jira statuses

### DIFF
--- a/NEW_MOD_TECH_EVAL_JIRA.md
+++ b/NEW_MOD_TECH_EVAL_JIRA.md
@@ -21,6 +21,10 @@ The submission may be resubmitted at a later time.
 
 **UNDER TC REVIEW** Once the evaluation is complete, the evaluation group communicates the results and transitions the issue to this state.
 
+**DEFERRED** The TC transitions the issue to this state if it has deferred the TCR for significant work (i.e. an RFC) from the Submitter.  See [Review](NEW_MODULE_TECH_EVAL.md/Review).
+
+**PROVISIONALLY APPROVED** As explained in [Review](NEW_MODULE_TECH_EVAL.md/Review), the TC transitions the issue to this state temporarily after provisionally accepting a module.
+
 **APPROVED** Once the evaluation results are reviewed by the TC and the submission is approved, the TC transitions the issue to this state.
 
 **REJECTED** Once the evaluation results are reviewed by the TC and the submission is rejected, the TC transitions the issue to this state. 

--- a/NEW_MOD_TECH_EVAL_JIRA.md
+++ b/NEW_MOD_TECH_EVAL_JIRA.md
@@ -16,12 +16,12 @@ This document outlines the JIRA Project and Workflow used by the New Module Tech
 
 **UNDER EVALUATION** Once the submission is reviewed by the TC and an evaluation group is formed, the TC indicates this by transitioning the issue to this state.
 
-**CANCELLED** If the submitter decides to withdraw the submission (alone or together with the evalation group), he/she transitions the issue to this state.
+**CANCELLED** If the submitter decides to withdraw the submission (alone or together with the evaluation group), he/she transitions the issue to this state.
 The submission may be resubmitted at a later time.
 
-**UNDER TC REVIEW** Once the evaluation is complete, the evalution group communicates the results and transitions the issue to this state.
+**UNDER TC REVIEW** Once the evaluation is complete, the evaluation group communicates the results and transitions the issue to this state.
 
-**APPROVED** Once the evalution results are reviewed by the TC and the submission is approved, the TC transtions the issue to this state.
+**APPROVED** Once the evaluation results are reviewed by the TC and the submission is approved, the TC transitions the issue to this state.
 
-**REJECTED** Once the evalution results are reviewed by the TC and the submission is rejected, the TC transtions the issue to this state. 
+**REJECTED** Once the evaluation results are reviewed by the TC and the submission is rejected, the TC transitions the issue to this state. 
 The submitter may resubmit the submission once the failed criteria are addressed.


### PR DESCRIPTION
On the Jira page, document the [Deferred](https://github.com/folio-org/tech-council/blob/master/NEW_MODULE_TECH_EVAL.MD?plain=1#L78) and [Provisionally Approved](https://github.com/folio-org/tech-council/blob/master/NEW_MODULE_TECH_EVAL.MD?plain=1#L79) statuses introduced in the most recent [TCR Process Improvements](https://github.com/folio-org/tech-council/pull/55/files).