### PR TITLE
Fix broken links to info on environment variables in ModuleDescriptor (DR-000020)

### DIFF
--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -85,7 +85,7 @@ Note: Backend criteria apply to modules, shared backend libraries, and edge modu
   * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
 * Environment vars are documented in the ModuleDescriptor (5, 11)
-  * -_note: read more at [https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module](https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module)_
+  * -_note: read more at [DR-000020 - Teams must document deployment requirements in a clear & consistent way](https://folio-org.atlassian.net/wiki/spaces/TC/pages/5055298/DR-000020+-+Teams+must+document+deployment+requirements+in+a+clear+consistent+way)_
 * If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section, and must conform to FOLIO [interface naming conventions](https://dev.folio.org/guidelines/naming-conventions/#interfaces) (3, 5)
 * All API endpoints are documented in OpenAPI (11)
 * All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using *.all permissions, all necessary module permissions are assigned, etc. (6)

--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -85,7 +85,7 @@ Note: Backend criteria apply to modules, shared backend libraries, and edge modu
   * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
 * Environment vars are documented in the ModuleDescriptor (5, 11)
-  * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
+  * -_note: read more at [https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module](https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module)_
 * If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section, and must conform to FOLIO [interface naming conventions](https://dev.folio.org/guidelines/naming-conventions/#interfaces) (3, 5)
 * All API endpoints are documented in OpenAPI (11)
 * All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using *.all permissions, all necessary module permissions are assigned, etc. (6)

--- a/MODULE_EVALUATION_TEMPLATE.MD
+++ b/MODULE_EVALUATION_TEMPLATE.MD
@@ -50,7 +50,7 @@ When performing a technical evaluation of a module, create a copy of this docume
   * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * [ ] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
 * [ ] Environment vars are documented in the ModuleDescriptor
-  * -_note: read more at [https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module](https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module)_
+  * -_note: read more at [DR-000020 - Teams must document deployment requirements in a clear & consistent way](https://folio-org.atlassian.net/wiki/spaces/TC/pages/5055298/DR-000020+-+Teams+must+document+deployment+requirements+in+a+clear+consistent+way)_
 * [ ] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section, and must conform to FOLIO [interface naming conventions](https://dev.folio.org/guidelines/naming-conventions/#interfaces).
 * [ ] All API endpoints are documented in OpenAPI.
 * [ ] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.

--- a/MODULE_EVALUATION_TEMPLATE.MD
+++ b/MODULE_EVALUATION_TEMPLATE.MD
@@ -50,7 +50,7 @@ When performing a technical evaluation of a module, create a copy of this docume
   * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * [ ] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
 * [ ] Environment vars are documented in the ModuleDescriptor
-  * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
+  * -_note: read more at [https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module](https://folio-org.atlassian.net/wiki/spaces/SYSOPS/pages/2097733/Change+Environment+Variables+of+a+Module)_
 * [ ] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section, and must conform to FOLIO [interface naming conventions](https://dev.folio.org/guidelines/naming-conventions/#interfaces).
 * [ ] All API endpoints are documented in OpenAPI.
 * [ ] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.


### PR DESCRIPTION
See the wayback machine for the former destination of the dead link:

https://web.archive.org/web/20230529032519/https://wiki.folio.org/pages/viewpage.action?pageId=65110683

Obsoletes #62