### PR TITLE
Clarify what 'major' severity code smell means

### DIFF
--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -57,7 +57,7 @@ Please see [Before Development](MODULE_EVALUATION_TEMPLATE#before-development) f
   * _This is not applicable to libraries_
 * Must not depend on a FOLIO library that has not been approved through the TCR process
 * Gracefully handles the absence of third party systems or related configuration. (3, 5, 12)
-* Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication (6); and any disabled or intentionally ignored rules/recommendations are reasonably justified.
+* Sonarqube hasn't identified any security issues, major (high or greater severity) code smells or excessive (>3%) duplication (6); and any disabled or intentionally ignored rules/recommendations are reasonably justified.
   * See [Rule Customization](https://dev.folio.org/guides/code-analysis/#rule-customization) details. 
 * Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools (3, 5, 13)
 * Unit tests have 80% coverage or greater, and are based on [officially supported technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)[^1] (3, 4)

--- a/MODULE_EVALUATION_TEMPLATE.MD
+++ b/MODULE_EVALUATION_TEMPLATE.MD
@@ -28,7 +28,7 @@ When performing a technical evaluation of a module, create a copy of this docume
 * [ ] Module is written in a language and framework from the [officially supported technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page[^1]
 * [ ] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
 * [ ] Module gracefully handles the absence of third party systems or related configuration
-* [ ] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication (6); and any disabled or intentionally ignored rules/recommendations are reasonably justified.
+* [ ] Sonarqube hasn't identified any security issues, major (high or greater severity) code smells or excessive (>3%) duplication (6); and any disabled or intentionally ignored rules/recommendations are reasonably justified.
   * See [Rule Customization](https://dev.folio.org/guides/code-analysis/#rule-customization) details. 
 * [ ] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools[^1]
 * [ ] Unit tests have 80% coverage or greater, and are based on [officially supported technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)[^1]


### PR DESCRIPTION
Sonar doesn't use the term 'major' to categorize code smells or other issues.  To make the criteria actionable, we should have a common definition.  On the Issues tab, they range from Blocker down to Info.

I interpret "major" as meaning High or Blocker, but not Medium, Low or Info.