### PR TITLE
Forbid default password/access key/private key/credential

### DIFF
--- a/MODULE_ACCEPTANCE_CRITERIA.MD
+++ b/MODULE_ACCEPTANCE_CRITERIA.MD
@@ -75,6 +75,7 @@ Use these conventions to indicate the status of each criterion.
 * [ ] [Personal data form](https://github.com/folio-org/personal-data-disclosure) is completed, accurate, and provided as PERSONAL_DATA_DISCLOSURE.md file (6)
   * _This is not applicable to libraries_
 * [ ] Sensitive and environment-specific information is not checked into git repository (6)
+* [ ] There is no default for any password, access key, private key or any other credential (6)
 * [ ] Written in a language and framework from the [officially supported technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page[^1] (3, 5)
 * [ ] Uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn’t been accepted yet_ (3, 5, 12)
   * _This is not applicable to libraries_


### PR DESCRIPTION
If there is a default for a password, access key, private key or any other credential it is unsecure.

If a value is needed it must be provided (environment variable, vault, ...) to reduce the risk that an unsecure default is used unintentionally.